### PR TITLE
Add + Set default CV Terms system variables

### DIFF
--- a/analyzedphenotypes.install
+++ b/analyzedphenotypes.install
@@ -184,7 +184,8 @@ function analyzedphenotypes_enable() {
   // Set default.
   foreach($system_vars as $v => $var) {
     // Set the variable to default ontology term.
-    $v = str_replace('', 'ap_', $v);
+    // base terms: location, replicate, year ...
+    $v = trim(str_replace('ap_', '', $v));
 
     variable_set($var, $default_ontology[$v]);
   }

--- a/analyzedphenotypes.install
+++ b/analyzedphenotypes.install
@@ -173,6 +173,7 @@ function analyzedphenotypes_enable() {
     'warning');
 
 
+  // Initialize Variables:
   // Load default ontology terms for method, location, replicate, collector, genus, related and year
   // in AP configuration page.
   $default_ontology = analyzedphenotypes_defaultontologyload();
@@ -186,6 +187,24 @@ function analyzedphenotypes_enable() {
     $v = str_replace('', 'ap_', $v);
 
     variable_set($var, $default_ontology[$v]);
+  }
+
+  // Other system variables.
+  // Genus - cv, db and ontology.
+  unset($system_vars);
+  $system_vars = analyzedphenotypes_systemvariables('cvdbon');
+
+  foreach($system_vars as $v => $var) {
+    foreach($var as $h) {
+      variable_set($h, 'not set');
+    }
+  }
+
+  // Allow new traits.
+  unset($system_vars);
+  $system_vars = analyzedphenotypes_systemvariables('options');
+  foreach($system_vars as $v => $var) {
+    variable_set($var, 1);
   }
 }
 

--- a/analyzedphenotypes.install
+++ b/analyzedphenotypes.install
@@ -4,7 +4,12 @@
  */
 
 // Make the API available during install.
+
+// AP API.
 module_load_include('inc', 'analyzedphenotypes', 'api/analyzedphenotypes.api');
+// Default Ontology Terms API.
+module_load_include('inc', 'analyzedphenotypes', 'api/analyzedphenotypes.defaultontology.api');
+
 
 /**
  * Implements hook_enable().
@@ -166,7 +171,24 @@ function analyzedphenotypes_enable() {
     'Analyzed Phenotypes needs to be configured <a href="@url">here</a> in order to be specific to your system.',
     array('@url' => url('admin/tripal/extension/analyzedphenotypes/settings'))),
     'warning');
+
+
+  // Load default ontology terms for method, location, replicate, collector, genus, related and year
+  // in AP configuration page.
+  $default_ontology = analyzedphenotypes_defaultontologyload();
+
+  // System variable for all controlled vocabulary terms.
+  $system_vars = analyzedphenotypes_systemvariables('terms');
+
+  // Set default.
+  foreach($system_vars as $v => $var) {
+    // Set the variable to default ontology term.
+    $v = str_replace('', 'ap_', $v);
+
+    variable_set($var, $default_ontology[$v]);
+  }
 }
+
 
 /**
  * Implements hook_install().
@@ -185,6 +207,7 @@ function analyzedphenotypes_install() {
     }
   }
 }
+
 
 /**
  * Implements hook_uninstall().

--- a/analyzedphenotypes.module
+++ b/analyzedphenotypes.module
@@ -6,7 +6,11 @@
  */
 
 
+// AP API.
 module_load_include('inc', 'analyzedphenotypes', 'api/analyzedphenotypes.api');
+// Default Ontology Terms API.
+module_load_include('inc', 'analyzedphenotypes', 'api/analyzedphenotypes.defaultontology.api.inc');
+// Validators.
 module_load_include('inc', 'analyzedphenotypes', 'include/analyzedphenotypes.validators');
 
 

--- a/api/analyzedphenotypes.api.inc
+++ b/api/analyzedphenotypes.api.inc
@@ -1436,7 +1436,6 @@ function analyzedphenotypes_systemvars($property = null) {
  * @see analyzedphenotypes_ap_validators() in validators.inc.
  * @see analyzedphenotypes_save_tsv_data() in admin.form.inc.
  * @see analyzedphenotypes_cvprop() in api.inc.
- * @see analyzedphenotypes_defaultontologynames() in defaultontology.inc.
  * @see hook_install() implementation in install.inc.
  */
 function analyzedphenotypes_systemvariables($property = null) {
@@ -1453,16 +1452,13 @@ function analyzedphenotypes_systemvariables($property = null) {
     'terms'   => 'terms',
   );
 
-  // All base names of ontology terms as part of the variable name.
-  $base_names = analyzedphenotypes_defaultontologynames();
-
   // System variable names.
   $var_name = array(
     // To register additional system variable, add here.
 
     $var_type['options'] => array('allownew'),
     $var_type['cvdbon']  => array('cv', 'db', 'ontology'),
-    $var_type['terms']   => $base_names,
+    $var_type['terms']   => array('genus', 'year', 'method', 'related', 'location', 'replicate', 'collector')
   );
 
   // Array to hold all system variables.

--- a/api/analyzedphenotypes.api.inc
+++ b/api/analyzedphenotypes.api.inc
@@ -561,7 +561,7 @@ function analyzedphenotypes_datatypeprop($property, $parameter = null) {
       }
 
       break;
-      
+
     //
     case 'number_no_zero':
       // Numbers, no 0.
@@ -791,7 +791,7 @@ function analyzedphenotypes_cvprop($property = null, $parameter = null) {
             ':cvterm_id' => $cvprop['cvterm_id'],
           )
         );
-        
+
         $cvprop['crop_ontology'] = ($result->rowCount() == 1) ? $result->fetchField() : null;
 
         // Scale.
@@ -848,7 +848,7 @@ function analyzedphenotypes_cvprop($property = null, $parameter = null) {
             'scale_to' => 400,
           ));
 
-          $photo_dir = 'public://ap-photo'; 
+          $photo_dir = 'public://ap-photo';
           file_prepare_directory($photo_dir, FILE_CREATE_DIRECTORY);
 
           $new_image = imagecreatetruecolor($scale['width'], $scale['height']);
@@ -1251,7 +1251,7 @@ function analyzedphenotypes_ontologyprop($property = null, $parameter = null) {
       $vars = analyzedphenotypes_systemvars('genus_ontology');
       $var_name = 'ap_' . strtolower(str_replace(' ', '_', $parameter['project_genus']));
       $cv_id = variable_get($vars[$var_name]['var']);
-      
+
       $ontology_terms = analyzedphenotypes_cvprop('terms_in_cv', array(
         'cv_id' => $cv_id,
       ));
@@ -1269,7 +1269,7 @@ function analyzedphenotypes_ontologyprop($property = null, $parameter = null) {
         if ($i == $default_ontology['cvterm_id']) {
           continue;
         }
-        
+
         $ontology = strtolower(trim($term['name']));
         $keywords = explode(' ', $ontology);
 
@@ -1282,11 +1282,11 @@ function analyzedphenotypes_ontologyprop($property = null, $parameter = null) {
               $ontologyprop[$i] = $term;
 
               $ctr++;
-            }  
+            }
           }
         }
       }
-        
+
       $ontologyprop[$default_ontology['cvterm_id']] = array(
         'name' => $default_ontology['name'],
         'definition' => $default_ontology['definition'],
@@ -1299,18 +1299,18 @@ function analyzedphenotypes_ontologyprop($property = null, $parameter = null) {
       $vars = analyzedphenotypes_systemvars('genus_ontology');
       $var_name = 'ap_' . strtolower(str_replace(' ', '_', $parameter['project_genus']));
       $cv_id = variable_get($vars[$var_name]['var']);
-      
+
       $cvtermprop = analyzedphenotypes_cvprop('get_cvterm', array(
         'name' => $parameter['ontology'],
         'cv_id' => $cv_id,
       ));
-      
+
       if ($cvtermprop) {
           $ontologyprop[$cvtermprop['cvterm_id']] = $cvtermprop['name'];
       }
-      
+
       break;
-    
+
     //
     // Additional case here.
 
@@ -1388,13 +1388,13 @@ function analyzedphenotypes_systemvars($property = null) {
       $systemvars = $vars_database;
 
       break;
-    
+
     //
     case 'plant_property':
       $systemvars = $vars_plantprop;
 
       break;
-    
+
     //
     case 'genus_ontology':
       $systemvars = $vars_ontology;
@@ -1406,6 +1406,130 @@ function analyzedphenotypes_systemvars($property = null) {
 
     default:
       $systemvars = $vars_database + $vars_plantprop + $vars_ontology;
+  }
+
+
+  return $systemvars;
+}
+
+
+/**
+ * API: SYSTEM VARIABLE
+ * Manage property and operation pertaining to system variable.
+ * Default to: Return variables.
+ * Dependencies: analyzedphenotypes_genusprop().
+ *               analyzedphenotypes default ontology API.
+ *
+ * @param String $property
+ *   A value representing a property/operation requested (each property represents a case in the switch implementation):
+ *   Default to null.
+ *   - options  : Variables for system options (eg. allow new term).
+ *   - cvdbon   : Controlled vocabulary, database and otology settings per genus.
+ *   - terms    : CV/ontology terms location, replicate, method and etc.
+ *   - default  : All variables defined.
+ *
+ * @return Array $systemvars
+ *   Array of variables names.
+ *
+ * @see analyzedphenotypes_admin_settings() in admin.form.inc.
+ * @see analyzedphenotypes_loader_form_save() in admin.form.inc.
+ * @see analyzedphenotypes_ap_validators() in validators.inc.
+ * @see analyzedphenotypes_save_tsv_data() in admin.form.inc.
+ * @see analyzedphenotypes_cvprop() in api.inc.
+ * @see analyzedphenotypes_defaultontologynames() in defaultontology.inc.
+ * @see hook_install() implementation in install.inc.
+ */
+function analyzedphenotypes_systemvariables($property = null) {
+  $systemvars = null;
+  $basename = 'analyzedphenotypes_systemvar_';
+
+  // System variable types.
+  $var_type = array(
+    // Allow new header to be added during upload.
+    'options' => 'options',
+    // Controlled vocabulary (cv), database (db) etc.
+    'cvdbon'  => 'cvdbon',
+    // Controlled vocabulary terms etc.
+    'terms'   => 'terms',
+  );
+
+  // All base names of ontology terms as part of the variable name.
+  $base_names = analyzedphenotypes_defaultontologynames();
+
+  // System variable names.
+  $var_name = array(
+    // To register additional system variable, add here.
+
+    $var_type['options'] => array('allownew'),
+    $var_type['cvdbon']  => array('cv', 'db', 'ontology'),
+    $var_type['terms']   => $base_names,
+  );
+
+  // Array to hold all system variables.
+  $system_variables = array();
+
+  // Construct system variables.
+  // Variables are reference using ap_ . name combination.
+  // eg. ap_genus, ap_method etc.
+  foreach($var_name as $i => $var) {
+    if ($i == $var_type['cvdbon']) {
+      // Per genus : controlled vocabulary, database and ontology variables.
+      $genus = analyzedphenotypes_genusprop();
+
+      // Construct variables.
+      // eg. LENS: cv - analyzedphenotypes_systemvar_lens_cv.
+      //           db - analyzedphenotypes_systemvar_lens_db.
+      //           ontology - analyzedphenotypes_systemvar_lens_ontology.
+      foreach($genus as $g) {
+        $g = strtolower(str_replace(' ', '_', $g));
+
+        foreach($var as $v) {
+          $system_variables[$i]['ap_' . $g][$v] = $basename . $g . '_' . $v;
+        }
+      }
+    }
+    else {
+      // Other terms.
+      // eg. TERM METHOD: analyzedphenotypes_systemvar_method.
+      foreach($var as $v) {
+        $system_variables[$i]['ap_' . $v] = $basename . $v;
+      }
+    }
+  }
+
+  // Handle system variables request.
+  switch($property) {
+    //
+    case 'options':
+      // Return variables in options category.
+      // Allow new ...
+      $systemvars = $system_variables[ $var_type['options'] ];
+
+      break;
+
+    //
+    case 'cvdbon':
+      // Return variables in cv, db and ontology category per genus.
+      // lens_cv, lens_db ...
+      $systemvars = $system_variables[ $var_type['cvdbon'] ];
+
+      break;
+
+    //
+    case 'terms':
+      // Return variables in terms category.
+      // methods, related, genus ...
+      $systemvars = $system_variables[ $var_type['terms'] ];
+
+      break;
+
+    //
+    // Define additional case here.
+
+    //
+    default:
+      // All variables.
+      $systemvars = $system_variables;
   }
 
 

--- a/api/analyzedphenotypes.defaultontology.api.inc
+++ b/api/analyzedphenotypes.defaultontology.api.inc
@@ -14,10 +14,22 @@
  *   definition and subsequent controlled vocabulary terms.
  *
  * @see analyzedphenotypes_defaultontologyload() in file.
- * @see analyzedphenotypes_defaultontologynames() in file.
  */
 function analyzedphenotypes_defaultontologydefine() {
   $ontology = array();
+
+  // Array to associate each term to predefine terms.
+  // Predefined Terms => Matching name in terms array definition below (case-sensitive).
+  $map_term = array(
+    'genus'     => 'genus',
+    'year'      => 'Year',
+    'method'    => 'method',
+    'related'   => 'related',
+    'location'  => 'location',
+    'replicate' => 'replicate',
+    'collector' => 'Collected By',
+  );
+
 
   // YEAR - TRIPAL PUB, TRIPAL CORE:
   $ontology['tripal_pub'] = array(
@@ -110,7 +122,10 @@ function analyzedphenotypes_defaultontologydefine() {
   );
 
 
-  return $ontology;
+  return array(
+    'terms' => $ontology,
+    'map_term' => $map_term,
+  );
 }
 
 
@@ -133,7 +148,7 @@ function analyzedphenotypes_defaultontologyload() {
   $ontology_load = array();
 
   // Each controlled vocabulary - cv.
-  foreach($ontology as $abbrev => $details) {
+  foreach($ontology['terms'] as $abbrev => $details) {
     // Each term in a Controlled Vocabulary cv.
     foreach($details['terms'] as $term) {
       // Fetch the term, see if previously added.
@@ -154,44 +169,15 @@ function analyzedphenotypes_defaultontologyload() {
 
       // CV TERM NAME.
       $name = ($t) ? $t->name : $ins_cvterm->name;
-      // Match to system variable base name by adding prefix ap_.
-      $base = strtolower(str_replace(' ', '_', $name));
+      // Match predefined variable to cvterm saved.
+      $map_term = array_search($name, $ontology['map_term']);
 
-      // Save term to used as configuration page default settings.
-      $ontology_load[$base] = ($t) ? $t->cvterm_id : $ins_cvterm->cvterm_id;
+      // Save term to be used as configuration page default settings.
+      // eg. ap_location = 1231.
+      $ontology_load[$map_term] = ($t) ? $t->cvterm_id : $ins_cvterm->cvterm_id;
     }
   }
 
 
   return $ontology_load;
-}
-
-
-/**
- * FUNCTION: Fetch ontology terms name convert to single string value
- * and use as system variable names.
- *
- * Dependencies: analyzedphenotypes_defaultontologydefine().
- *
- * @return
- *   An array, all ontology term names converted to a single string value,
- *   in lowercase letters and all spaces converted to underscore character _.
- *
- * @see analyzedphenotypes_systemvariables() in api.inc.
- */
-function analyzedphenotypes_defaultontologynames() {
-  $ontology = analyzedphenotypes_defaultontologydefine();
-
-  // This array will hold all base names.
-  $ontology_names = array();
-
-  foreach($ontology as $abbrev => $details) {
-    foreach($details['terms'] as $term) {
-      // lowecase and spaces to _
-      $ontology_names[] = strtolower(str_replace(' ', '_', $term['name']));
-    }
-  }
-
-
-  return $ontology_names;
 }

--- a/api/analyzedphenotypes.defaultontology.api.inc
+++ b/api/analyzedphenotypes.defaultontology.api.inc
@@ -1,0 +1,197 @@
+<?php
+/**
+ * @file
+ * Contains Default Controlled Vocabulary terms.
+ * Source: TRIPAL CORE - http://tripal.info
+ *         ONTOBEE - http://www.ontobee.org
+ */
+
+/**
+ * FUNCTION: Define controlled vocabulary terms required by this system.
+ *
+ * @return
+ *   An array, where the key is the controlled vocabulary name and value contains
+ *   definition and subsequent controlled vocabulary terms.
+ *
+ * @see analyzedphenotypes_defaultontologyload() in file.
+ * @see analyzedphenotypes_defaultontologynames() in file.
+ */
+function analyzedphenotypes_defaultontologydefine() {
+  $ontology = array();
+
+  // YEAR - TRIPAL PUB, TRIPAL CORE:
+  $ontology['tripal_pub'] = array(
+    'name' => 'tripal_pub',
+    'definition' => 'Tripal Publication Ontology. A temporary ontology until a more formal appropriate ontology to be identified.',
+    'all terms' => FALSE,
+
+    'terms' => array(
+      array(
+        'id'     => 'TPUB:0000059',
+        'name'     => 'Year',
+        'definition' => 'The year the work was published. This should be a 4 digit year.',
+      ),
+
+      // Additional terms here.
+    ),
+  );
+
+  // GENUS - TAXONOMIC RANK, TRIPAL CORE:
+  $ontology['taxonomic_rank'] = array(
+    'name' => 'taxonomic_rank',
+    'definition' => 'A vocabulary of taxonomic ranks (species, family, phylum, etc).',
+    'all terms' => FALSE,
+
+    'terms' => array(
+      array(
+        'id'    => 'TAXRANK:0000005',
+        'name'     => 'genus',
+        'definition' => 'The genus.',
+      ),
+
+      // Additional terms here.
+    ),
+
+  );
+
+  // RELATED - SYNONYM TYPE, TRIPAL CORE:
+  $ontology['synonym_type'] = array(
+    'name' => 'synonym_type',
+    'definition' => 'A local vocabulary added for synonynm types.',
+    'all terms' => FALSE,
+
+    'terms' => array(
+      array(
+        'id'     => 'internal:related',
+        'name'     => 'related',
+        'definition' => 'Is related to.',
+      ),
+
+      // Additional terms here.
+    )
+
+  );
+
+  // METHOD, LOCATION, REPLICATE, COLLECTED BY - NCIT:
+  $ontology['NCIT'] = array(
+    'name' => 'NCIT',
+    'definition' => 'The NCIT OBO Edition project aims to increase integration of the NCIt with OBO Library ontologies
+      NCIt is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases,
+      findings and abnormalities. NCIt OBO Edition releases should be considered experimental.',
+    'all terms' => FALSE,
+
+    'terms' => array(
+      array(
+        'id'     => 'NCIT:C71460',
+        'name'     => 'method',
+        'definition' => 'A means, manner of procedure, or systematic course of action that have to be performed in order
+          to accomplish a particular goal.',
+      ),
+      array(
+        'id' => 'NCIT:C25341',
+        'name' => 'location',
+        'definition' => 'A position, site, or point in space where something can be found.',
+      ),
+      array(
+        'id'     => 'NCIT:C28038',
+        'name'     => 'replicate',
+        'definition' => 'A role played by a biological sample in the context of an experiment where the intent is that
+          biological or technical variation is measured.'
+      ),
+      array(
+        'id'     => 'NCIT:C45262',
+        'name'     => 'Collected By',
+        'definition' => 'Indicates the person, group, or institution who performed the collection act.',
+      ),
+
+      // Additional terms here.
+    ),
+
+  );
+
+
+  return $ontology;
+}
+
+
+/**
+ * FUNCTION: Insert into chado.cvterm or test existence of a cvterm.
+ * and return cvterm id to be set as default value in configuration page.
+ *
+ * Dependencies: analyzedphenotypes_defaultontologydefine().
+ *
+ * @return
+ *   An array, controlled vocabulary terms cvterm id.
+ *
+ * @see analyzedphenotypes_defaultontologydefine() in file.
+ * @see hook_install() implementation in install.inc.
+ */
+function analyzedphenotypes_defaultontologyload() {
+  $ontology = analyzedphenotypes_defaultontologydefine();
+
+  // This array to hold default controlled vocabulary terms used in this system.
+  $ontology_load = array();
+
+  // Each controlled vocabulary - cv.
+  foreach($ontology as $abbrev => $details) {
+    // Each term in a Controlled Vocabulary cv.
+    foreach($details['terms'] as $term) {
+      // Fetch the term, see if previously added.
+      $t = tripal_get_cvterm(array(
+        'name' => $term['name'],
+        'cv_id' => array('name' => $details['name']),
+      ));
+
+      if (!$t) {
+        // Term not in chado.cvterm. Insert!
+        // #1. Controlled vocabulary.
+        $ins_cv = tripal_insert_cv($details['name'], $details['definition']);
+
+        // #2. Terms.
+        $term['cv_name'] = $details['name'];
+        $ins_cvterm = tripal_insert_cvterm($term);
+      }
+
+      // CV TERM NAME.
+      $name = ($t) ? $t->name : $ins_cvterm->name;
+      // Match to system variable base name by adding prefix ap_.
+      $base = strtolower(str_replace(' ', '_', $name));
+
+      // Save term to used as configuration page default settings.
+      $ontology_load[$base] = ($t) ? $t->cvterm_id : $ins_cvterm->cvterm_id;
+    }
+  }
+
+
+  return $ontology_load;
+}
+
+
+/**
+ * FUNCTION: Fetch ontology terms name convert to single string value
+ * and use as system variable names.
+ *
+ * Dependencies: analyzedphenotypes_defaultontologydefine().
+ *
+ * @return
+ *   An array, all ontology term names converted to a single string value,
+ *   in lowercase letters and all spaces converted to underscore character _.
+ *
+ * @see analyzedphenotypes_systemvariables() in api.inc.
+ */
+function analyzedphenotypes_defaultontologynames() {
+  $ontology = analyzedphenotypes_defaultontologydefine();
+
+  // This array will hold all base names.
+  $ontology_names = array();
+
+  foreach($ontology as $abbrev => $details) {
+    foreach($details['terms'] as $term) {
+      // lowecase and spaces to _
+      $ontology_names[] = strtolower(str_replace(' ', '_', $term['name']));
+    }
+  }
+
+
+  return $ontology_names;
+}


### PR DESCRIPTION
Add and set default CV Terms location, year, replicate, collector, method and genus system variables.

To Test:
1. Start by querying Drupal variables for variable names prefixed with analyzed...
to ensure that variables do not exists.
2. Disable - Enable analyzedphenotypes module.
3. Query the Drupal variables table again to see if variables were defined as expected.

