### PR TITLE
Issue # 15 - Save term id and load term name into fields

### DIFF
--- a/api/analyzedphenotypes.api.inc
+++ b/api/analyzedphenotypes.api.inc
@@ -652,6 +652,7 @@ function analyzedphenotypes_datatypeprop($property, $parameter = null) {
  *   - cvterm_get_photo  : Get photo information.
  *   - suggest_term      : Suggest cvterm name with the cv name it is in.
  *   - term_cv           : Given a string containing cvterm name and cv name (eg. Genus (taxonomic_rank)) in fields, return the cvterm id.
+ *   - term_id           : Given a cvterm id number return a string value containing the cvterm name and cv name in cvterm name (cv name) format.
  *   - default           : All records in chado.cv.
  * @param Array $parameter
  *   An associtive array that forms as arguments to an operation.
@@ -662,6 +663,7 @@ function analyzedphenotypes_datatypeprop($property, $parameter = null) {
  *   - name
  *   - photo
  *   - term_cv
+ *   - project_genus
  *
  * @return $cvprop
  *   Array of term properties.
@@ -924,6 +926,22 @@ function analyzedphenotypes_cvprop($property = null, $parameter = null) {
         WHERE CONCAT(t1.name, ' (' , t2.name , ')') = :term_cv LIMIT 1",
         array(
           ':term_cv' => $parameter['term_cv']
+        )
+      );
+
+      if ($result->rowCount() > 0) {
+        $cvprop = $result->fetchField();
+      }
+
+      break;
+
+    //
+    case 'term_id':
+      $result = chado_query(
+        "SELECT t1.name || ' (' || t2.name || ')' AS term FROM {cvterm} AS t1 INNER JOIN {cv} AS t2
+        USING(cv_id) WHERE t1.cvterm_id = :term_id LIMIT 1",
+        array(
+          ':term_id' => $parameter['term_id'],
         )
       );
 

--- a/include/analyzedphenotypes.admin.form.inc
+++ b/include/analyzedphenotypes.admin.form.inc
@@ -1199,7 +1199,7 @@ function analyzedphenotypes_admin_settings($form, &$form_state) {
     '#type' => 'submit',
     '#value' => 'Save Ontology Configuration',
     '#validate' => array('system_settings_form_validate'),
-    '#submit' => array('system_settings_form_submit'),
+    '#submit' => array('system_settings_form_config_submit'),
   );
 
 
@@ -1298,14 +1298,23 @@ function analyzedphenotypes_admin_settings($form, &$form_state) {
       }
 
       // Get default.
-      $default_field = variable_get($prop['field_name']);
+      // Since what is saved is cvterm_id into the variable, we need to convert the id
+      // to something human readbale.
+      $var_id = variable_get($prop['field_name']);
+      $default_field = analyzedphenotypes_cvprop('term_id', array(
+        'term_id' => $var_id,
+      ));
+
+      $default_value = (empty($default_field)) ? '' : $default_field;
 
       // Otherwise a autocomplete field.
       $form[$frameset_cv][ $prop['field_name'] ] = array(
         '#type' => 'textfield',
         '#title' => t($term),
         '#description' => t($prop['description']),
-        '#default_value' => (!empty($default_field)) ? $default_field : '',
+        '#default_value' => $default_value,
+        '#attributes' => array('class' => array('ap-autocomplete-field-terms'),
+          'title' => array($default_value)),
         //
         '#autocomplete_path' => 'admin/tripal/extension/analyzedphenotypes/json/cvterms/cv',
       );
@@ -1313,6 +1322,13 @@ function analyzedphenotypes_admin_settings($form, &$form_state) {
 
     $i++;
   }
+
+  // Select field value when clicked to ease typing in new value.
+  drupal_add_js('jQuery(document).ready(function() {
+    jQuery(".ap-autocomplete-field-terms").focusin(function(){
+      jQuery(this).select();
+    });
+  })', 'inline');
 
   // Warning.
   $form[$frameset_cv]['warning'] = array(
@@ -1328,7 +1344,7 @@ function analyzedphenotypes_admin_settings($form, &$form_state) {
     '#type' => 'submit',
     '#value' => 'Save Term Configuration',
     '#validate' => array('system_settings_form_validate'),
-    '#submit' => array('system_settings_form_submit'),
+    '#submit' => array('system_settings_form_config_submit'),
   );
 
 
@@ -1398,4 +1414,51 @@ function system_settings_form_validate($form, &$form_state) {
       }
     }
   }
+}
+
+
+/**
+ * FUNCTION CALLBACK:
+ * Save congfiguration variables.
+ */
+function system_settings_form_config_submit($form, &$form_state) {
+  $vars = analyzedphenotypes_systemvariables();
+
+  foreach($vars as $i => $var) {
+    // Convert the values selected from the interface to id number (cvterm or cv id number).
+    if ($i == 'cvdbon') {
+      // Genus cv, db and ontology.
+      // Select field returns the id number, no processing required.
+      foreach ($var as $v) {
+        foreach($v as $k) {
+          $fld_value = $form_state['values'][$k];
+          variable_set($k, $fld_value);
+        }
+      }
+    }
+    elseif ($i == 'options') {
+      // Options. Allow new traits added to upload.
+      // 1 or 0 value. No processing required,
+      foreach ($var as $v) {
+        $fld_value = $form_state['values'][$v];
+
+        variable_set($v, $fld_value);
+      }
+    }
+    elseif ($i == 'terms') {
+      // Controlled vocabulary term.
+      // Autocomplete returns cvterm name (cv term) format, requires cvterm_id number.
+      foreach ($var as $v) {
+        $fld_value = $form_state['values'][$v];
+
+        $fld_value_id = analyzedphenotypes_cvprop('term_cv', array(
+          'term_cv' => $fld_value,
+        ));
+
+        variable_set($v, $fld_value_id);
+      }
+    }
+  }
+
+  drupal_set_message('Configuration saved.', 'status');
 }


### PR DESCRIPTION
Added function to save term id and load human readable term names into field in configuration page.

To test:
1. Disable module, then uninstall it.
2. Using dev/execute php terminal delete all system variables (this will be addressed in the next issue). 
3. With all system variables cleared, Enable the module. Again, ignore old variable names.
4. Load configuration page.
Notice all default cvterm ids from previous branch are now replaced with a name.
5. Test Validation:
  - Enter in non-existent term (eg. Lorem :) ) click save - Should get term does not exists error message.
  - Leave term empty - Should get term x field is empty error message.
  - Set one of the 3 fields in genus and leave the rest to default - Should get select cv/db error message.
6. To see value saved.
  ```
$m = chado_query("select name from variable where name like '%analyzed%'")
->fetchAll();

foreach($m as $n) {
  $k = variable_get($n->name);  
  echo $n->name . ' - ' . $k . "\n";
}
 ```

Additional update:
- added inline script to select field value when clicked to ease entering new value.