### PR TITLE
Replaced progress bar in second stage

### DIFF
--- a/theme/analyzedphenotypes_pages.tpl.php
+++ b/theme/analyzedphenotypes_pages.tpl.php
@@ -75,7 +75,9 @@ if ($form_id == $ap . 'uploaddata_form') {
                 <div class="ap-tsv-file-form-element"><label>TSV Data File</label><span>Validating...</span></div>
 
                 <div id="ap-progress-container" class="ap-tsv-file-form-element">
-                  <div class="ap-progress-wrapper">
+                  <div class="ap-navy-spinner">Validating data... Please wait.</div>
+                  <!-- Apply progress bar - disable display rule to use progress bar instead of spinner above !-->
+                  <div class="ap-progress-wrapper" style="display: none">
                     <div class="progress-pane"></div>
                   </div>
                 </div>
@@ -193,39 +195,3 @@ else {
   print '</ul>';
 }
 ?>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/theme/css/analyzedphenotypes.loader.progress.css
+++ b/theme/css/analyzedphenotypes.loader.progress.css
@@ -25,3 +25,11 @@
   text-align:center;
   display: none;
 }
+
+
+/* Navy AJAX wait - spinner */
+.ap-navy-spinner {
+  background: url('../../theme/img/wait-validating.gif') no-repeat top center;
+  padding: 75px 90px 10px 90px !important;
+  text-align: center;
+}


### PR DESCRIPTION
Reserved progress bar exclusive to the last stage - save data stage only and used navy spinner for stages that performed validation.

## Metadata
[https://github.com/UofS-Pulse-Binfo/analyzedphenotypes/issues/38]

- [X] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
Defined a new css rule to implement a spinner and applied the rule to a div element where the progress bar markup. Progress bar can still be restored by switching a rule to display in case progress bar is desired over the spinner.

## Dependencies
This PR is not dependent upon other PR.

## Testing?
Upload a spreadsheet file to stage 2.
![screen shot 2018-11-06 at 1 53 11 pm](https://user-images.githubusercontent.com/15472253/48090008-6aba3900-e1cb-11e8-8dd4-55270594e785.png)


- [ ] I tested on a generic Tripal Site
- [X] I tested on a KnowPulse Clone
in dev/A
- [ ] This PR includes automated testing
