### PR TITLE
Configuration for unit and method

### DIFF
--- a/api/analyzedphenotypes.ontology.api.inc
+++ b/api/analyzedphenotypes.ontology.api.inc
@@ -29,6 +29,7 @@ function ap_define_defaultontology() {
     'genus'     => 'genus',
     'year'      => 'Year',
     'method'    => 'method',
+    'unit'      => 'unit',
     'related'   => 'related',
     'location'  => 'location',
     'replicate' => 'replicate',
@@ -86,7 +87,24 @@ function ap_define_defaultontology() {
     )
   );
 
-  // METHOD, LOCATION, REPLICATE, COLLECTED BY - NCIT:
+  // METHOD => UNIT - UNIT
+  $ontology['uo'] = array(
+    'name' => 'uo',
+    'definition' => 'Units of Measurement Ontology.',
+    'all terms' => FALSE,
+
+    'terms' => array(
+      array(
+        'id'     => 'UO:0000000',
+        'name'     => 'unit',
+        'definition' => '',
+      ),
+
+      // Additional terms here.
+    )
+  );
+
+  // TRAIT => METHOD, LOCATION, REPLICATE, COLLECTED BY - NCIT:
   $ontology['NCIT'] = array(
     'name' => 'NCIT',
     'definition' => 'The NCIT OBO Edition project aims to increase integration of the NCIt with OBO Library ontologies
@@ -168,7 +186,7 @@ function ap_load_defaultontology() {
         // Term not in chado.cvterm. Insert!
         // #1. Controlled vocabulary.
         if (function_exists('chado_insert_cv')) {
-          $ins_cv = chado_insert_cv($details['name'], $details['definition']);          
+          $ins_cv = chado_insert_cv($details['name'], $details['definition']);
         }
         else {
           $ins_cv = tripal_insert_cv($details['name'], $details['definition']);

--- a/api/analyzedphenotypes.systemvars.api.inc
+++ b/api/analyzedphenotypes.systemvars.api.inc
@@ -38,7 +38,7 @@ function ap_construct_variablenames() {
   $var_suffix = array(
     $var_set['options'] => array('allownew'),
     $var_set['cvdbon'] => array('cv', 'db', 'ontology', 'method', 'unit'),
-    $var_set['terms'] => array('genus', 'year', 'method', 'related', 'location', 'replicate', 'collector')
+    $var_set['terms'] => array('genus', 'year', 'method', 'unit', 'related', 'location', 'replicate', 'collector')
 
     // To register system variables in a set, add here.
     //

--- a/api/analyzedphenotypes.systemvars.api.inc
+++ b/api/analyzedphenotypes.systemvars.api.inc
@@ -37,7 +37,7 @@ function ap_construct_variablenames() {
   // NOTE: each item must be in lowercase and spaces should be replaced with underscore.
   $var_suffix = array(
     $var_set['options'] => array('allownew'),
-    $var_set['cvdbon'] => array('cv', 'db', 'ontology'),
+    $var_set['cvdbon'] => array('cv', 'db', 'ontology', 'method', 'unit'),
     $var_set['terms'] => array('genus', 'year', 'method', 'related', 'location', 'replicate', 'collector')
 
     // To register system variables in a set, add here.
@@ -58,6 +58,8 @@ function ap_construct_variablenames() {
       // This set is linked to each genus such that
       // a genus would have a cv, db and on (ontology) variable name.
       // eg. LENS: cv - analyzedphenotypes_systemvar_lens_cv.
+      //           method - analyzedphenotypes_systemvar_lens_method.
+      //           unit - analyzedphenotypes_systemvar_lens_unit.
       //           db - analyzedphenotypes_systemvar_lens_db.
       //           on - analyzedphenotypes_systemvar_lens_ontology.
       $result = chado_query(
@@ -83,7 +85,7 @@ function ap_construct_variablenames() {
       }
     }
   }
-  
+
 
   return $systemvars;
 }

--- a/api/analyzedphenotypes.trait.api.inc
+++ b/api/analyzedphenotypes.trait.api.inc
@@ -72,6 +72,20 @@ function ap_insert_trait($data) {
   ));
   $cv_name = $cvprop['name'];
 
+  //  - Method Controlled Vocabulary (cv). Used in the cv_name in cvterm property array below.
+  $sysvar_genus_method = variable_get($sysvar['method']);
+  $cvprop = ap_get_cv(array(
+    'cv_id' => $sysvar_genus_method
+  ));
+  $method_cvname = $cvprop['name'];
+
+  //  - Unit Controlled Vocabulary (cv). Used in the cv_name in cvterm property array below.
+  $sysvar_genus_unit = variable_get($sysvar['unit']);
+  $cvprop = ap_get_cv(array(
+    'cv_id' => $sysvar_genus_unit
+  ));
+  $unit_cvname = $cvprop['name'];
+
   // Insert the trait cvterm
   if (!isset($data['trait_id'])) {
     $trait_cvterm = array(
@@ -98,7 +112,7 @@ function ap_insert_trait($data) {
   if (!$exists) {
     // Insert the method cvterm
     $method_cvterm = array(
-      'cv_name' => $cv_name, // @todo we shouldnt use the same cv... @config-needed
+      'cv_name' => $method_cvname,
       'id' => trim($db_name) . ':' . $data['method_title'],
       'name' => $data['method_title'],
       'definition' => $data['method'],
@@ -114,7 +128,7 @@ function ap_insert_trait($data) {
 
   // Insert the unit cvterm
   $unit_cvterm = array(
-    'cv_name' => $cv_name, // @todo we shouldnt use the same cv... @config-needed
+    'cv_name' => $unit_cvname,
     'id' => trim($db_name) . ':' . $data['unit'],
     'name' => $data['unit'],
     'definition' => '',
@@ -250,7 +264,7 @@ function ap_get_method_units($project_genus, $method, $options = [], $method_id 
 
   // If we don't have the trait cvterm_id then look it up.
   if (!$method_id) {
-    $method_id = ap_get_method_id($method);
+    $method_id = ap_get_method_id($project_genus, $method);
   }
 
   // Now look up all method cvterm_ids for that trait using the relationship.
@@ -293,7 +307,7 @@ function ap_get_method_id($project_genus, $method) {
     // @todo @config-needed
     $sysvar = ap_get_variablenames(
       array('variablename' => $project_genus),
-      array('set' => 'cvdbon', 'suffix' => 'cv')
+      array('set' => 'cvdbon', 'suffix' => 'method')
     );
     $cv_id = variable_get($sysvar);
 
@@ -325,7 +339,7 @@ function ap_get_unit_id($project_genus, $unit) {
     // @todo @config-needed
     $sysvar = ap_get_variablenames(
       array('variablename' => $project_genus),
-      array('set' => 'cvdbon', 'suffix' => 'cv')
+      array('set' => 'cvdbon', 'suffix' => 'unit')
     );
     $cv_id = variable_get($sysvar);
 

--- a/api/analyzedphenotypes.trait.api.inc
+++ b/api/analyzedphenotypes.trait.api.inc
@@ -155,12 +155,14 @@ function ap_insert_trait($data) {
   }
 
   // Relate Trait => Method
+  $sysvar = ap_get_variablenames(
+    array('variablename' => 'method'),
+    array('set' => 'terms')
+  );
+  $type_id = variable_get($sysvar);
   $values = array(
     'subject_id' => $trait_cvterm->cvterm_id,
-    'type_id' => array(
-      'cv_id' => array('name' => 'NCIT'), // @todo @config-needed
-      'name' => 'method',
-    ),
+    'type_id' => $type_id,
     'object_id' => $method_cvterm->cvterm_id,
   );
   $exists = chado_select_record('cvterm_relationship', array('cvterm_relationship_id'), $values);
@@ -169,12 +171,14 @@ function ap_insert_trait($data) {
   }
 
   // Relate Method => Unit
+  $sysvar = ap_get_variablenames(
+    array('variablename' => 'unit'),
+    array('set' => 'terms')
+  );
+  $type_id = variable_get($sysvar);
   $values = array(
     'subject_id' => $method_cvterm->cvterm_id,
-    'type_id' => array(
-      'cv_id' => array('name' => 'uo'), // @todo @config-needed
-      'name' => 'unit',
-    ),
+    'type_id' => $type_id,
     'object_id' => $unit_cvterm->cvterm_id,
   );
   $exists = chado_select_record('cvterm_relationship', array('cvterm_relationship_id'), $values);
@@ -226,13 +230,15 @@ function ap_get_trait_methods($project_genus, $trait_name, $options = [], $trait
   }
 
   // Now look up all method cvterm_ids for that trait using the relationship.
+  $sysvar = ap_get_variablenames(
+    array('variablename' => 'method'),
+    array('set' => 'terms')
+  );
+  $type_id = variable_get($sysvar);
   $results = chado_select_record('cvterm_relationship', array('object_id'),
     array(
       'subject_id' => $trait_id,
-      'type_id' => array(
-        'cv_id' => array('name' => 'NCIT'), // @todo @config-needed
-        'name' => 'method',
-      ),
+      'type_id' => $type_id,
     )
   );
 
@@ -268,13 +274,15 @@ function ap_get_method_units($project_genus, $method, $options = [], $method_id 
   }
 
   // Now look up all method cvterm_ids for that trait using the relationship.
+  $sysvar = ap_get_variablenames(
+    array('variablename' => 'unit'),
+    array('set' => 'terms')
+  );
+  $type_id = variable_get($sysvar);
   $results = chado_select_record('cvterm_relationship', array('object_id'),
     array(
       'subject_id' => $method_id,
-      'type_id' => array(
-        'cv_id' => array('name' => 'uo'), // @todo @config-needed
-        'name' => 'unit',
-      ),
+      'type_id' => $type_id,
     )
   );
 
@@ -304,7 +312,6 @@ function ap_get_method_id($project_genus, $method) {
 
     // Retrieve the CV the traits are stored in.
     // Currently we are using the same cv as the trait...
-    // @todo @config-needed
     $sysvar = ap_get_variablenames(
       array('variablename' => $project_genus),
       array('set' => 'cvdbon', 'suffix' => 'method')
@@ -336,7 +343,6 @@ function ap_get_unit_id($project_genus, $unit) {
 
     // Retrieve the CV the traits are stored in.
     // Currently we are using the same cv as the trait...
-    // @todo @config-needed
     $sysvar = ap_get_variablenames(
       array('variablename' => $project_genus),
       array('set' => 'cvdbon', 'suffix' => 'unit')

--- a/include/analyzedphenotypes.configuration.page.inc
+++ b/include/analyzedphenotypes.configuration.page.inc
@@ -234,10 +234,16 @@ function analyzedphenotypes_configuration_form($form, &$form_state) {
         adding a "genus" property to it.'),
     ),
     'Method' => array(
-      'title' => 'Method',
+      'title' => 'Trait => Method',
       'default' => '',
       'field_name' => $term_vars['ap_method'],
-      'description'  => t('This term indicates that a given trait propery describes the method with which the data was taken.'),
+      'description'  => t('This term describes the relationship between your trait vocabulary term and the method with which the data was taken.'),
+    ),
+    'Unit' => array(
+      'title' => 'Method => Unit',
+      'default' => '',
+      'field_name' => $term_vars['ap_unit'],
+      'description'  => t('This term describes the relationship between your method and the unit with which it was measured.'),
     ),
     'Related' => array(
       'title' => 'Related',

--- a/include/analyzedphenotypes.configuration.page.inc
+++ b/include/analyzedphenotypes.configuration.page.inc
@@ -57,9 +57,11 @@ function analyzedphenotypes_configuration_form($form, &$form_state) {
   // System vars basename.
   $basename = 'analyzedphenotypes_systemvar_';
   $var_token = array(
-    1 => array('cv', 'Select Vocabulary'),
-    2 => array('db', 'Select Database'),
-    3 => array('ontology', 'Select Crop Ontology'),
+    1 => array('cv', 'Select Trait Vocabulary'),
+    2 => array('method', 'Select Method Vocabulary'),
+    3 => array('unit', 'Select Unit Vocabulary'),
+    4 => array('db', 'Select Database'),
+    5 => array('ontology', 'Select Crop Ontology'),
   );
 
   // Fetch all Controlled Vocabulary.
@@ -89,49 +91,58 @@ function analyzedphenotypes_configuration_form($form, &$form_state) {
 
     // Each genus requires 4 columns - genus title, cv, db and ontology.
     $j = 0;
-    while ($j < 4) {
+    while ($j <= 5) {
       if ($j == 0) {
         // If 0 or column genus of the table - print the genus text.
-        $field_prop = array(
+        $field_name = $genus_key . '_title';
+        $fields[ 'ap_field_row_' . $i ][0][$field_name] = array(
           '#type' => 'item',
           '#title' => t(ucfirst($g)),
         );
 
-        $field_name = $genus_key . '_title';
       }
+      // Else, construct a select box.
       else {
-        // Else, construct a select box.
-        $field_options = ($j == 2) ? $db_options : $cv_options;
 
-        // Find if a config has been set.
+        // Set the options for this specific select box.
+        // Options for column 2 are databases but all other are c. vocabs.
+        $field_options = ($j == 4) ? $db_options : $cv_options;
 
+        // Find if a config has been set and set it as the default.
         $var_value = variable_get($basename . $genus_key . '_' . $var_token[$j][0]);
+        $field_default = NULL;
         if (isset($var_value)) {
           $field_default = $var_value;
         }
 
-        $is_disabled = FALSE;
-        if ($j == 1 AND is_integer($field_default)) {
-          // Inspect if this genus has data attached to it and disable it.
-          $has_data = chado_query($sql, array(':cv_id' => $field_default))
-            ->fetchAll();
+        // Inspect if this genus has data attached to it and disable it.
+        if ($j == 1) {
+          $is_disabled = FALSE;
+          if ($j == 1 AND is_integer($field_default)) {
 
-          $is_disabled = ($has_data) ? TRUE : FALSE;
+            $has_data = chado_query($sql, array(':cv_id' => $field_default))
+              ->fetchAll();
+            $is_disabled = ($has_data) ? TRUE : FALSE;
+          }
         }
 
-        $field_prop = array(
+        $col = 1;
+        if ($j == 4) { $col = 2; }
+        if ($j == 5) { $col = 3; }
+
+        // Finally, the select box!
+        $field_name = $basename . $genus_key . '_' . $var_token[$j][0];
+        $fields[ 'ap_field_row_' . $i ][$col][$field_name] = array(
           '#type' => 'select',
           '#title' => '',
-          '#options' => array(0 => $var_token[$j][1]) + $field_options,
+          '#empty_option' => $var_token[$j][1],
+          '#options' => $field_options,
           '#attributes' => array('class' => array('ap-table-select-field')),
           '#default_value' => $field_default,
           '#disabled' => $is_disabled,
         );
 
-        $field_name = $basename . $genus_key . '_' . $var_token[$j][0];
       }
-
-      $fields[ 'ap_field_row_' . $i ][$field_name] = $field_prop;
 
       $j++;
     }
@@ -142,7 +153,7 @@ function analyzedphenotypes_configuration_form($form, &$form_state) {
 
   $form[$frameset_to]['ap_formfield_table'] = array(
     '#theme' => 'analyzedphenotypes_form_table',
-    '#header' => array(t('<b>Genus</b>'), t('Trait Vocabulary'), t('Associated Database'), t('Crop Ontology')),
+    '#header' => array(t('<b>Genus</b>'), t('Trait Vocabularies'), t('Associated Database'), t('Crop Ontology')),
     'rows' => array(
       '#tree' => FALSE,
     ) + $fields,

--- a/include/analyzedphenotypes.configuration.page.inc
+++ b/include/analyzedphenotypes.configuration.page.inc
@@ -365,6 +365,7 @@ function system_settings_form_validate($form, &$form_state) {
     array('variablename' => 'varset'),
     array('set' => 'cvdbon')
   );
+  dpm($cvdbon, '$cvdbon');
 
   foreach($cvdbon as $i => $vars) {
     $var_ctr = 0;
@@ -382,8 +383,18 @@ function system_settings_form_validate($form, &$form_state) {
     if ($var_ctr > 0) {
       // Field set.
       if ($form_state['values'][$vars['cv']] <= 0) {
-        // Controlled vocabulary.
-        form_set_error($vars['cv'], 'Please select Controlled Vocabulary for ' . $var_key . ' genus.');
+        // Trait Controlled vocabulary.
+        form_set_error($vars['cv'], 'Please select Trait Vocabulary for ' . $var_key . ' genus.');
+      }
+
+      if ($form_state['values'][$vars['method']] <= 0) {
+        // Method Controlled vocabulary.
+        form_set_error($vars['method'], 'Please select Method Vocabulary for ' . $var_key . ' genus.');
+      }
+
+      if ($form_state['values'][$vars['unit']] <= 0) {
+        // Unit Controlled vocabulary.
+        form_set_error($vars['unit'], 'Please select Unit Vocabulary for ' . $var_key . ' genus.');
       }
 
       if ($form_state['values'][$vars['db']] <= 0) {

--- a/include/analyzedphenotypes.configuration.page.inc
+++ b/include/analyzedphenotypes.configuration.page.inc
@@ -365,7 +365,6 @@ function system_settings_form_validate($form, &$form_state) {
     array('variablename' => 'varset'),
     array('set' => 'cvdbon')
   );
-  dpm($cvdbon, '$cvdbon');
 
   foreach($cvdbon as $i => $vars) {
     $var_ctr = 0;

--- a/include/analyzedphenotypes.traitplot.page.inc
+++ b/include/analyzedphenotypes.traitplot.page.inc
@@ -354,6 +354,7 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
   // Construct chart text/wordings.
   $experiment_name = chado_query('SELECT name FROM {project} WHERE project_id=:id', array(':id' => $experiment_id))->fetchField();
   $trait_name = chado_query('SELECT name FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $trait_id))->fetchField();
+  $definition = chado_query('SELECT definition FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $trait_id))->fetchField();
   $unit = chado_query('SELECT name FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $unit_id))->fetchField();
   $method = chado_query('SELECT definition FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $method_id))->fetchField();
 
@@ -370,10 +371,10 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
     $xaxis = 'Site-Year';
     $yaxis = $trait_name.' ('.$unit.')';
     $figtitle = "Comparison of observed $trait_name between site years for <em>$experiment_name</em>.";
-    $figlegend = "$trait_name was measured in $unit. "
+    $figlegend = "$trait_name was measured in $unit. $definition"
      . $method . " Replicates were then averaged per germplasm within a single site-year."
      . " The chart shows the traditional box plot with the kernel density estimation flanking it."
-     . " Thus $trait_name values in a wider section of the plot represent higher probability that "
+     . " Thus values in a wider section of the plot represent higher probability that "
      . "members of the sampled germplasm collection will show that phenotype.";
   }
   else {
@@ -464,12 +465,14 @@ function analyzedphenotypes_traitplot_json($project_id, $trait_id, $method_id, $
 
   if ($project_id && $trait_id && $method_id && $unit_id) {
     $resource = chado_query(
-      "SELECT location, year, stock_name, values
-        FROM chado.mview_phenotype
-        WHERE experiment_id=:project_id
-          AND trait_id=:trait_id
-          AND method_id= :method_id
-          AND unit_id=:unit_id
+      "SELECT mview.location, mview.year, mview.stock_name, mview.values, prop.value as chart_type
+        FROM chado.mview_phenotype mview
+        LEFT JOIN {cvtermprop} prop ON prop.cvterm_id=mview.unit_id
+        WHERE mview.experiment_id=:project_id
+          AND mview.trait_id=:trait_id
+          AND mview.method_id= :method_id
+          AND mview.unit_id=:unit_id
+          AND prop.type_id IN (SELECT cvterm_id FROM chado.cvterm WHERE name='additionalType')
         ORDER BY year ASC, location ASC",
       array(
         ':project_id' => $project_id,
@@ -480,7 +483,7 @@ function analyzedphenotypes_traitplot_json($project_id, $trait_id, $method_id, $
     foreach($resource as $r) {
 
       $values = json_decode($r->values);
-      if (is_numeric($values[0])) {
+      if ($r->chart_type == 'quantitative') {
         $mean = array_sum($values) / count($values);
       }
       else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #47 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [x] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
When we upgraded the data storage method, we created the need for additional cv's and cvterms in the configuration. Specifically we needed to allow per organism config of method and unit cv and which cvterms should be used for Trait=>Method and Method=>Unit relationships.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

This test requires updating of default variable options. This is usually done in .install but can be done after the fact using the code sample below:

```php
module_load_include('inc','analyzedphenotypes','/api/analyzedphenotypes.ontology.api');
$default_ontology = ap_load_defaultontology();

$sysvars = ap_construct_variablenames();
  foreach($sysvars['terms'] as $v => $var) {
    // Set the variable to default ontology term.
    // base terms: location, replicate, year ...
    $v = trim(str_replace('ap_', '', $v));

    variable_set($var, $default_ontology[$v]);
  }
```

For Testing, 
1. Go to the configuration form and confirm there are now trait/method/unit options per organism 
<img width="1070" alt="screen shot 2019-02-04 at 2 52 16 pm" src="https://user-images.githubusercontent.com/1566301/52236511-aaf18c00-288c-11e9-9fed-7bb6f5671ed8.png">
2. In the configuration form, confirm there is a Trait=>Method and Method=>Unit, both with defaults.
<img width="1074" alt="screen shot 2019-02-04 at 2 54 52 pm" src="https://user-images.githubusercontent.com/1566301/52236585-d96f6700-288c-11e9-979e-d8fa6daed219.png">
3. Try inserting a trait and ensure at the database level that the cvterms are in the correct cv and are connected in cvterm_relationship using the correct type_id.

```php
$info = ap_insert_trait([
  'genus' => 'Tripalus',
  'name' => 'test trait2',
  'description' => 'I though the name was pretty self explanatory',
  'method_title' => 'accurate1',
  'method' => 'A super accurate measurement method for something made up.',
  'unit' => 'Kelvin',
  'type' => 'quant',
]);
dpm($info, 'info');
```