### PR TITLE
Fix determination of qualitative vs. quantitative

### DIFF
--- a/api/analyzedphenotypes.api.inc
+++ b/api/analyzedphenotypes.api.inc
@@ -399,7 +399,7 @@ function ap_construct_datafile_destinationpath() {
 
   // Construct relative/absolute path eg. public://tripal/analzedphenotypes/spreadsheet
   // - for data file
-  $file_dir[$dir] = $drupal_public . $ap_root_dir;
+  $file_dir[$ap_root_dir] = $drupal_public . $ap_root_dir;
   foreach($directory as $dir) {
     $file_dir[$dir] = $drupal_public . $ap_root_dir . $dir;
   }

--- a/api/analyzedphenotypes.trait.api.inc
+++ b/api/analyzedphenotypes.trait.api.inc
@@ -50,7 +50,7 @@ function ap_insert_trait($data) {
 
   // Defaults.
   if (!isset($data['type'])) {
-    $data['type'] = 'qualitative';
+    $data['type'] = 'quantitative';
   }
   if ($data['type'] == 'qual') {
     $data['type'] = 'qualitative';

--- a/tests/upload/APFileUploadHelper.php
+++ b/tests/upload/APFileUploadHelper.php
@@ -73,6 +73,7 @@ class APFileUploadHelper {
         'method' => $faker->sentences(5, true),
         'unit' => $d['unit'],
         'genus' => $organism->genus,
+        'type' => $d['type'],
       ]);
 
       // @debug print_r($results);

--- a/tests/upload/fileUploadTest.php
+++ b/tests/upload/fileUploadTest.php
@@ -21,6 +21,7 @@ class fileUploadTest extends TripalTestCase {
       'trait_name' => 'Lorem ipsum',
       'method_name' =>'dolor sit amet',
       'unit' => 'metris',
+      'type' => 'quantitative',
     );
     $info = \APFileUploadHelper::loadFile('SHORT-TestData-1trait1method.tsv', $traits_in_file);
 
@@ -58,6 +59,12 @@ class fileUploadTest extends TripalTestCase {
       "We did not get the number of units we expected.");
     $this->assertEquals($info['units']['metris'], $records[0]->unit_id,
       "We did not get the unit cvterm_id we expected.");
+
+    // Test the method is of the correct type: qualitative or quantitative.
+    $type = chado_query("SELECT value FROM {cvtermprop} WHERE cvterm_id=:id AND type_id IN (SELECT cvterm_id FROM {cvterm} WHERE name='additionalType')",
+      array(':id' => $info['units']['metris']))->fetchField();
+    $this->assertEquals('quantitative',$type,
+      "The unit metris was not quantitative.");
   }
 
   /**
@@ -73,11 +80,13 @@ class fileUploadTest extends TripalTestCase {
       'trait_name' => 'Lorem ipsum',
       'method_name' =>'dolor sit amet',
       'unit' => 'metris',
+      'type' => 'qualitative',
     );
     $traits_in_file[] = array(
       'trait_name' => 'Lorem ipsum',
       'method_name' =>'vitae aliquet arcu',
       'unit' => 'metris',
+      'type' => 'qualitative',
     );
     $info = \APFileUploadHelper::loadFile('SHORT-TestData-1trait2methods.tsv', $traits_in_file);
 
@@ -98,7 +107,7 @@ class fileUploadTest extends TripalTestCase {
     $this->assertEquals($info['traits']['Lorem ipsum'], $records[0]->attr_id,
       "We did not get the trait cvterm_id we expected.");
 
-    // Check that there is only a single method.
+    // Check that there are two methods.
     $records = chado_query(
       'SELECT DISTINCT assay_id FROM {phenotype} WHERE project_id=:project',
       array(':project' => $info['project']->project_id))->fetchAll();
@@ -111,5 +120,12 @@ class fileUploadTest extends TripalTestCase {
       array(':project' => $info['project']->project_id))->fetchAll();
     $this->assertEquals(1, sizeof($records),
       "We did not get the number of units we expected.");
+
+    // Test the method is of the correct type: qualitative or quantitative.
+    $type = chado_query("SELECT value FROM {cvtermprop} WHERE cvterm_id=:id AND type_id IN (SELECT cvterm_id FROM {cvterm} WHERE name='additionalType')",
+      array(':id' => $info['units']['metris']))->fetchField();
+    $this->assertEquals('qualitative',$type,
+      "The unit metris was not qualitative.");
+
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue n/a

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds automated testing to ensure the type of method is set properly. It also changes the default type to quantitative.

## Dependencies
<!-- If this code is dependent upon another module and/or PR, 
       state that here. -->
<!-- Include information about other modules/PRs needed for testing,
        which to enable/merge first, etc. -->
None

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [x] This PR includes automated testing

1. Create a project (Admin » Add Tripal Content » Project)
2. Create germplasm for your file
```php
$species = 'databasica';
for ($i=1; $i <= 15; $i++) {
  $stock = [
     'name' => 'GERM'.$i,
     'uniquename' => 'ID:'.$i,
     'type_id' => ['name' => 'SNP'],
     'organism_id' => ['species' => $species],
  ];
  $stock = chado_insert_record(
    'stock',
     $stock
  );
}
```
3. Configure the module for your organism (Administration » Tripal » Extensions » Analyzed Phenotypes » Configuration) by selecting at least a "Trait Vocabulary" and "Associated DB". Which you choose doesn't matter for testing purposes other then to ensure the trait is added to the vocabulary when loaded. Documentation: https://analyzedphenotypes.readthedocs.io/en/latest/admin_guide/configuration.html
4. Upload a test file (Administration » Tripal » Extensions » Analyzed Phenotypes » Upload Phenotypic Data). Documentation: https://analyzedphenotypes.readthedocs.io/en/latest/user_guide/loading.html
5. Check the type for the methods you uploaded using the following query:
```sql
SELECT value
FROM chado.cvtermprop
WHERE 
  cvterm_id IN (SELECT cvterm_id FROM chado.cvterm WHERE name='YOUR UNIT HERE') AND
  type_id IN (SELECT cvterm_id FROM chado.cvterm WHERE name='additionalType');
```

NOTE: qualitative/quantitative are attached to the unit. In order to be detected as qualitative, a unit must have the word `Scale` in it; all other traits should be quantitative.