### PR TITLE
Add optional watermark to phenotype charts

### DIFF
--- a/analyzedphenotypes.info
+++ b/analyzedphenotypes.info
@@ -5,7 +5,7 @@ package = Tripal Extensions
 dependencies[] = dragndrop_upload_element
 dependencies[] = tripal
 dependencies[] = trpdownload_api
+dependencies[] = tripald3
 
 core = 7.x
 configure = admin/tripal/extension/analyzedphenotypes/settings
-

--- a/analyzedphenotypes.module
+++ b/analyzedphenotypes.module
@@ -85,11 +85,22 @@ function analyzedphenotypes_menu() {
 
   // CONFIGURATION PAGE:
 
-  $items[$tripal_extension_ap . '/configuration'] = array(
-    'title' => 'Configuration',
-    'description' => 'Set the controlled vocabularies to be used by this module, as well, as other options to customize it to your data/organism.',
+  $items[$tripal_extension_ap . '/setup'] = array(
+    'title' => 'Set-up Ontologies',
+    'description' => 'Set the controlled vocabularies to be used by this module, as well, as other options to customize it to your data.',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('analyzedphenotypes_configuration_form'),
+    'page arguments' => array('analyzedphenotypes_setup_form'),
+    'access arguments' => array('administer tripal'),
+    'file' => 'includes/analyzedphenotypes.configuration.page.inc',
+    'weight' => 2,
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  $items[$tripal_extension_ap . '/config'] = array(
+    'title' => 'Configure',
+    'description' => 'Customize the display of this module.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('analyzedphenotypes_config_form'),
     'access arguments' => array('administer tripal'),
     'file' => 'includes/analyzedphenotypes.configuration.page.inc',
     'weight' => 2,

--- a/includes/TripalFields/hp__phenotypic_variability/hp__phenotypic_variability_formatterforms.inc
+++ b/includes/TripalFields/hp__phenotypic_variability/hp__phenotypic_variability_formatterforms.inc
@@ -307,6 +307,18 @@ function analyzedphenotypes_hp_phenotypic_variability_single_chart_form(&$form, 
         . "as [first value]/[second value] where order is not meaningful.";
       }
 
+      // Do we want to add a watermark?
+      $add_watermark = variable_get('ap_config_watermark_what', 'all');
+      if ($add_watermark == 'all') {
+        tripald3_load_libraries();
+        $watermark_url = variable_get('ap_config_watermark_url', FALSE);
+        $add_watermark = TRUE;
+      }
+      else {
+        $add_watermark = FALSE;
+        $watermark_url = FALSE;
+      }
+
       // Add the needed JS for the chart.
       drupal_add_js($module_path . "/theme/js/$chart_type.chart.js", ['weight' => -3]);
       $data['analyzedPhenotypes'] = array();
@@ -319,6 +331,8 @@ function analyzedphenotypes_hp_phenotypic_variability_single_chart_form(&$form, 
           'unit_id' => $unit_id,
           'xaxis' => $xaxis,
           'yaxis' => $yaxis,
+          'addWatermark' => $add_watermark,
+          'watermarkURL' => $watermark_url,
       );
       drupal_add_js($data, 'setting');
       

--- a/includes/analyzedphenotypes.configuration.page.inc
+++ b/includes/analyzedphenotypes.configuration.page.inc
@@ -5,7 +5,63 @@
  * Contains configuration interface of this module.
  */
 
+/**
+ * Configure Display.
+ */
 
+/**
+ * Configuration: form.
+ */
+function analyzedphenotypes_config_form($form, $form_state) {
+
+  $form['watermark'] = array(
+    '#type' => 'fieldset',
+    '#title' => 'Watermark Charts',
+    '#description' => 'This allows you to add a partially transparent image of your choice in front of phenotypic data charts provided by this module. The intent is to provide data protection by preventing people from sharing screenshots without attribution. That said, people with advanced HTML/CSS knowledge will be able to remove the watermark. Please take additional steps to protect data if you are concerned.'
+  );
+
+  $form['watermark']['watermark_what'] = array(
+    '#type' => 'radios',
+    '#title' => 'Choose which charts should be watermarked.',
+    '#options' => array(
+      'all' => 'Watermark all charts',
+      'none' => 'Do not watermark any charts',
+    ),
+    '#default_value' => variable_get('ap_config_watermark_what', 'all'),
+  );
+
+  $form['watermark']['watermark_url'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Watermark Image URL',
+    '#description' => 'Upload your watermark to the public files directory and then provide the URL here (e.g. https://mysite.com/sites/default/files/mywatermark.png)',
+    '#default_value' => variable_get('ap_config_watermark_url', ''),
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Save',
+  );
+
+  return $form;
+}
+
+/**
+ * Configuration: Validate.
+ */
+function analyzedphenotypes_config_form_validate($form, $form_state) { }
+
+/**
+ * Configuration: Submit.
+ */
+function analyzedphenotypes_config_form_submit($form, $form_state) {
+
+  variable_set('ap_config_watermark_what', $form_state['values']['watermark_what']);
+  variable_set('ap_config_watermark_url', $form_state['values']['watermark_url']);
+}
+
+/**
+ * SET-UP Ontologies.
+ */
 
 // Ontologies API.
 module_load_include('inc', 'analyzedphenotypes', 'api/analyzedphenotypes.ontology.api');
@@ -15,7 +71,7 @@ module_load_include('inc', 'analyzedphenotypes', 'api/analyzedphenotypes.ontolog
  * Implements hook_form().
  * Construct module configuration page.
  */
-function analyzedphenotypes_configuration_form($form, &$form_state) {
+function analyzedphenotypes_setup_form($form, &$form_state) {
   // Check that chado orgnism table has at least a record (genus ie lens, lotus and cicer).
   $has_organism = ap_get_genus();
   if ($has_organism == 0) {

--- a/includes/analyzedphenotypes.configuration.page.inc
+++ b/includes/analyzedphenotypes.configuration.page.inc
@@ -17,7 +17,7 @@ function analyzedphenotypes_config_form($form, $form_state) {
   $form['watermark'] = array(
     '#type' => 'fieldset',
     '#title' => 'Watermark Charts',
-    '#description' => 'This allows you to add a partially transparent image of your choice in front of phenotypic data charts provided by this module. The intent is to provide data protection by preventing people from sharing screenshots without attribution. That said, people with advanced HTML/CSS knowledge will be able to remove the watermark. Please take additional steps to protect data if you are concerned.'
+    '#description' => 'This allows you to add a partially transparent image of your choice in front of phenotypic data charts provided by this module. The intent is to provide data protection by preventing people from sharing screenshots without attribution. <em>That said, people with advanced HTML/CSS knowledge will be able to remove the watermark. Please take additional steps to protect data if you are concerned.</em>'
   );
 
   $form['watermark']['watermark_what'] = array(

--- a/includes/analyzedphenotypes.traitplot.page.inc
+++ b/includes/analyzedphenotypes.traitplot.page.inc
@@ -397,6 +397,18 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
   $form['#attached']['js'][] = $module_path . '/theme/js/distroChart.js';
   $form['#attached']['js'][] = $module_path . "/theme/js/$chart_type.chart.js";
 
+  // Do we want to add a watermark?
+  $add_watermark = variable_get('ap_config_watermark_what', 'all');
+  if ($add_watermark == 'all') {
+    tripald3_load_libraries();
+    $watermark_url = variable_get('ap_config_watermark_url', FALSE);
+    $add_watermark = TRUE;
+  }
+  else {
+    $add_watermark = FALSE;
+    $watermark_url = FALSE;
+  }
+
   $data = array();
   $data['analyzedPhenotypes'] = array();
   $data['analyzedPhenotypes'][] = array(
@@ -408,6 +420,8 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
       'yaxis' => $yaxis,
       'id' => 'tripal-ap-violin-plot',
       'type' => $chart_type,
+      'addWatermark' => $add_watermark,
+      'watermarkURL' => $watermark_url,
   );
   $form['#attached']['js'][] = array(
     'type' => 'setting',

--- a/theme/js/multibar.chart.js
+++ b/theme/js/multibar.chart.js
@@ -189,6 +189,14 @@
               .style("text-anchor", "end")
               .text(function(d) {return d; });
 
+         if (apSettings.addWatermark) {
+           if (apSettings.watermarkURL !== false) {
+             tripalD3.placeWatermark({'watermark' : apSettings.watermarkURL});
+           }
+           else {
+             tripalD3.placeWatermark();
+           }
+         }
       }); //end of get json.
     }});
   }}; // End of Drupal Behaviours and associated attach.

--- a/theme/js/violin.chart.js
+++ b/theme/js/violin.chart.js
@@ -50,6 +50,15 @@
             colors:['#555']
           });
 
+          if (apSettings.addWatermark) {
+            if (apSettings.watermarkURL !== false) {
+              tripalD3.placeWatermark({'watermark' : apSettings.watermarkURL});
+            }
+            else {
+              tripalD3.placeWatermark();
+            }
+          }
+
         }); //end of get json.
       }
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #80 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds an configurable watermark to the trait distribution charts. This is helpful in the situation were data is not yet published and you want to protect it. The watermark is applied using the Tripal d3.js API and configurable at Tripal > Extensions > Analyzed Phenotypes > Configure. Additionally, this PR moves the ontology configuration into a `Set-up` since it only needs to be done once.

## Dependencies
This PR is not dependant on anything.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

On a site already containing analyzed phenotypic data:
1. Before configuring the watermark, open up a trait distribution chart at `[yoursite]/phenotypes/trait-distribution`, a project and a germplasm with which have a hp__phenotypic_variability field.
      - You should see the default tripald3 watermark.
2. Turn off the watermark at Tripal > Extensions > Analyzed Phenotypes > Configure. Now refresh those previously opened pages and the watermark should disappear.
3. Turn back on the watermark and add an image path. Now refresh those previously opened pages and your custom watermark should appear. Note: the image must exist already on the server.