### PR TITLE
Decouple chart type from qualitative/quantitative

### DIFF
--- a/analyzedphenotypes.install
+++ b/analyzedphenotypes.install
@@ -212,3 +212,94 @@ function analyzedphenotypes_requirements($phase) {
 
   return $requirements;
 }
+
+/**
+ * Implements hook_schema().
+ */
+function analyzedphenotypes_schema() {
+  $tables = [];
+
+  $tables['analyzedphenotypes_collections'] = [
+    'description' => 'Keeps track of phenotypic data collections; specifically, options for display.',
+    'fields' => [
+      'collection_id' => [
+        'description' => 'The primary identifier for a phenotypic data collection.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      ],
+      'genus' => [
+        'description' => 'The genus of the germplasm this data was taken on.',
+        'type' => 'varchar',
+        'not null' => TRUE,
+      ],
+      'trait_id' => [
+        'description' => 'The Trait (e.g. plant height).',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'method_id' => [
+        'description' => 'The Method (e.g. stretched primary stem).',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'unit_id' => [
+        'description' => 'The Unit (e.g. centimeters).',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'project_id' => [
+        'description' => 'The Experiment',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'chart_type' => [
+        'description' => 'The type of chart which should be used for display (e.g. "histogram", "violin").',
+        'type' => 'varchar',
+        'not null' => TRUE,
+      ],
+    ],
+    'unique keys' => [
+      'composite_key' => ['trait_id', 'method_id', 'unit_id', 'project_id'],
+    ],
+    'indexes' => [],
+    'primary key' => ['collection_id'],
+  ];
+
+  return $tables;
+}
+
+/**
+ * Create analyzedpenotypes_collections table and populate defaults.
+ */
+function analyzedphenotypes_update_7100() {
+
+  // Load the schema from mymodule_schema() so you don't have to duplicate code.
+  $schema = analyzedphenotypes_schema();
+
+  // Pass the table name and schema for that table to db_create_table()
+  db_create_table(
+    'analyzedphenotypes_collections',
+    $schema['analyzedphenotypes_collections']
+  );
+
+  // Populate the table for pre-existing collections.
+  $sql = "SELECT
+      pp.value as genus,
+      p.attr_id as trait_id,
+      p.assay_id as method_id,
+      p.unit_id,
+      p.project_id,
+      CASE
+        WHEN (up.value = 'quantitative') THEN 'violin'
+        ELSE 'histogram' END
+        as chart_type
+    FROM chado.phenotype p
+    LEFT JOIN chado.projectprop pp ON pp.project_id=p.project_id
+      AND pp.type_id IN (SELECT cvterm_id FROM chado.cvterm WHERE name='genus')
+    LEFT JOIN chado.cvtermprop up ON up.cvterm_id=p.unit_id
+      AND up.type_id IN (SELECT cvterm_id FROM chado.cvterm WHERE name='additionalType')
+    GROUP BY p.attr_id, p.assay_id, p.unit_id, p.project_id, pp.value, up.value";
+  db_query('INSERT INTO {analyzedphenotypes_collections}
+    (genus, trait_id, method_id, unit_id, project_id, chart_type)' . $sql);
+}

--- a/analyzedphenotypes.install
+++ b/analyzedphenotypes.install
@@ -254,7 +254,7 @@ function analyzedphenotypes_schema() {
         'not null' => TRUE,
       ],
       'chart_type' => [
-        'description' => 'The type of chart which should be used for display (e.g. "histogram", "violin").',
+        'description' => 'The type of chart which should be used for display (e.g. "multibar", "violin").',
         'type' => 'varchar',
         'not null' => TRUE,
       ],
@@ -292,7 +292,7 @@ function analyzedphenotypes_update_7100() {
       p.project_id,
       CASE
         WHEN (up.value = 'quantitative') THEN 'violin'
-        ELSE 'histogram' END
+        ELSE 'multibar' END
         as chart_type
     FROM chado.phenotype p
     LEFT JOIN chado.projectprop pp ON pp.project_id=p.project_id

--- a/includes/TripalImporter/APPhenotypeImporter.inc
+++ b/includes/TripalImporter/APPhenotypeImporter.inc
@@ -1132,6 +1132,13 @@ class APPhenotypeImporter extends TripalImporter {
     // We are using a separate function to load the file. It requires the fid.
     $fid = $arguments['files'][0]['fid'];
 
+    // Look up the project_id.
+    $projectprop = ap_match_projectname(
+      array('name' => $arguments['project_name']),
+      array('fullmatch' => TRUE, 'limitrows' => 1)
+    );
+    $project_id = ($projectprop) ? $projectprop['project_id'] : 0;
+
     // The function also requires the trat/method/unit IDs.
     $trait_ids = array();
     $method_ids = array();
@@ -1140,6 +1147,22 @@ class APPhenotypeImporter extends TripalImporter {
       $trait_ids[ $result['trait_name'] ] = $result['trait_id'];
       $method_ids[ $result['method_name'] ] = $result['method_id'];
       $unit_ids[ $result['unit'] ] = $result['unit_id'];
+
+      // Determine the default chart type based on unit name.
+      $chart_type = 'violin';
+      if (preg_match('([Ss]cale|\d+\s*-\s*\d+)', $result['method_name'])) {
+        $chart_type = 'histogram';
+      }
+
+      // Add the data collection with default chart type.
+      db_insert('analyzedphenotypes_collections')->fields([
+        'genus' => $arguments['genus'],
+        'project_id' => $project_id,
+        'trait_id' => $result['trait_id'],
+        'method_id' => $result['method_id'],
+        'unit_id' => $result['unit_id'],
+        'chart_type' => $chart_type,
+      ])->execute();
     }
 
     $dataset = [

--- a/includes/TripalImporter/APPhenotypeImporter.inc
+++ b/includes/TripalImporter/APPhenotypeImporter.inc
@@ -1151,7 +1151,7 @@ class APPhenotypeImporter extends TripalImporter {
       // Determine the default chart type based on unit name.
       $chart_type = 'violin';
       if (preg_match('([Ss]cale|\d+\s*-\s*\d+)', $result['method_name'])) {
-        $chart_type = 'histogram';
+        $chart_type = 'multibar';
       }
 
       // Add the data collection with default chart type.

--- a/includes/analyzedphenotypes.traitplot.page.inc
+++ b/includes/analyzedphenotypes.traitplot.page.inc
@@ -357,6 +357,8 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
   $definition = chado_query('SELECT definition FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $trait_id))->fetchField();
   $unit = chado_query('SELECT name FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $unit_id))->fetchField();
   $method = chado_query('SELECT definition FROM {cvterm} WHERE cvterm_id=:id', array(':id' => $method_id))->fetchField();
+  $chart_type = db_query('SELECT chart_type FROM {analyzedphenotypes_collections} WHERE project_id=:project_id AND trait_id=:trait_id AND method_id=:method_id AND unit_id=:unit_id',
+    ['project_id' => $experiment_id, 'trait_id' => $trait_id, 'method_id' => $method_id, 'unit_id' => $unit_id])->fetchField();
 
   // Determine the type of chart to show.
   // It should be stored as a property of the unit cvterm.
@@ -366,7 +368,6 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
       type_id IN (SELECT cvterm_id FROM {cvterm} WHERE name='additionalType')",
     array(':id' => $unit_id))->fetchField();
   if ($phenotype_type == 'quantitative' OR empty($phenotype_type)) {
-    $chart_type = 'violin';
 
     $xaxis = 'Site-Year';
     $yaxis = $trait_name.' ('.$unit.')';
@@ -378,7 +379,6 @@ function analyzedphenotypes_traitplot_form(&$form, &$form_state,
      . "members of the sampled germplasm collection will show that phenotype.";
   }
   else {
-    $chart_type = 'multibar';
 
     $xaxis = 'Site-Year';
     $yaxis = $trait_name.' ('.$unit.')';
@@ -484,7 +484,7 @@ function analyzedphenotypes_traitplot_json($project_id, $trait_id, $method_id, $
 
   if ($project_id && $trait_id && $method_id && $unit_id) {
     $resource = chado_query(
-      "SELECT mview.location, mview.year, mview.stock_name, mview.values, prop.value as chart_type
+      "SELECT mview.location, mview.year, mview.stock_name, mview.values, prop.value as data_type
         FROM chado.mview_phenotype mview
         LEFT JOIN {cvtermprop} prop ON prop.cvterm_id=mview.unit_id
         WHERE mview.experiment_id=:project_id
@@ -504,7 +504,7 @@ function analyzedphenotypes_traitplot_json($project_id, $trait_id, $method_id, $
       $values = json_decode($r->values);
       // QUANTITATIVE:
       // We want to average the replicates and provide a single value.
-      if ($r->chart_type == 'quantitative') {
+      if ($r->data_type == 'quantitative') {
         $mean = array_sum($values) / count($values);
         $results[] = array(
           'category' => $r->location . ' ' . $r->year,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #102

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
Currently the chart type (i.e. violin vs. histogram) is controlled by whether the unit is qualitative or quantitative. For example, the data for stem pigmentation measured with a scale 1-3 (qualitative) will show as a histogram and the same trait measured with a greenseeker (quantitative) will show as a violin.

However, there are other cases where you may prefer one chart type over another. For example, if there is only a single site-year (histogram) or the data is clearly bimodal (Violin). Thus we need a way to decouple the chart type from the unit.

## Dependencies
NONE

## Testing?
- [x] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

1. Switch to the branch on your development site.
2. Run updates: Admin toolbar > House > Run Updates
3. Check the database: `SELECT * FROM analyzedphenotypes_collections;`. The table should exist and be populated with one record for every unique trait/method/unit/project combination. 
4. Run `the following query. The chart_type should be multibar for qualitative traits and violin for quantitative.
```sql
SELECT coll.*, prop.value as data_type 
FROM analyzedphenotypes_collections coll 
LEFT JOIN chado.cvtermprop prop ON prop.cvterm_id=coll.unit_id;
```
5. Go to the trait distribution chart for a given data collection using the following URL template: `[yoursite]/phenotypes/trait-distribution/[project_id]/[trait_id]/[method_id]/[unit_id]`. Check the chart type matches that specified in the table.
6. Change the chart_type in the table and check the chart type changes as well.
```sql
UPDATE analyzedphenotypes_collections 
SET chart_type='violin' 
WHERE collection_id=5;
```