### PR TITLE
Germplasm search improvements

### DIFF
--- a/analyzedphenotypes.module
+++ b/analyzedphenotypes.module
@@ -135,6 +135,13 @@ function analyzedphenotypes_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items[$tripal_extension_ap . '/phenotyped-stock/json/%'] = array(
+    'page callback' => 'analyzedphenotypes_autocomplete_phenotyped_stock',
+    'page arguments' => array(6),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   // Generate validation result.
   $items[$tripal_extension_ap . '/validation_result/%/%'] = array(
     'page callback' => 'ap_report_validationresult',
@@ -300,6 +307,41 @@ function analyzedphenotypes_libraries_info() {
   return $libraries;
 }
 
+/**
+ * Used for autocomplete in forms for identifying stocks
+ *
+ * @param $string
+ *   The string to search for.
+ *
+ * @return
+ *   A json array of terms that begin with the provided string.
+ *
+ * @ingroup tripal_stock_api
+ */
+function analyzedphenotypes_autocomplete_phenotyped_stock($string = '') {
+  $items = [];
+  $sql = "
+    SELECT
+      B.stock_id as id, B.uniquename, B.name,
+      O.genus, O,species,
+      CVT.name as type
+    FROM {stock} B
+      INNER JOIN {organism} O ON O.organism_id = B.organism_id
+      INNER JOIN {cvterm} CVT ON CVT.cvterm_id = B.type_id
+      INNER JOIN {mview_phenotype} P ON P.stock_id=B.stock_id
+    WHERE
+      (lower(B.uniquename) like lower(:str)
+        OR lower(B.name) like lower(:str))
+    ORDER by B.name
+    LIMIT 25 OFFSET 0
+  ";
+  $records = chado_query($sql, [':str' => $string . '%']);
+  while ($r = $records->fetchObject()) {
+    $key = "$r->name [id: $r->id]";
+    $items[$key] = "$r->name ($r->uniquename, $r->type, $r->genus $r->species)";
+  }
+  drupal_json_output($items);
+}
 
 /**
  * Function callback: Convert query results or parameters suplied to an array of JSON object

--- a/analyzedphenotypes.module
+++ b/analyzedphenotypes.module
@@ -135,9 +135,9 @@ function analyzedphenotypes_menu() {
     'type' => MENU_CALLBACK,
   );
 
-  $items[$tripal_extension_ap . '/phenotyped-stock/json/%'] = array(
+  $items[$tripal_extension_ap . '/phenotyped-stock/json/%/%'] = array(
     'page callback' => 'analyzedphenotypes_autocomplete_phenotyped_stock',
-    'page arguments' => array(6),
+    'page arguments' => array(6,7),
     'access arguments' => array('access content'),
     'type' => MENU_CALLBACK,
   );
@@ -318,29 +318,32 @@ function analyzedphenotypes_libraries_info() {
  *
  * @ingroup tripal_stock_api
  */
-function analyzedphenotypes_autocomplete_phenotyped_stock($string = '') {
+function analyzedphenotypes_autocomplete_phenotyped_stock($trait_id, $string = '') {
   $items = [];
+
   $sql = "
     SELECT
       B.stock_id as id, B.uniquename, B.name,
-      O.genus, O,species,
+      O.genus, O.species,
       CVT.name as type
     FROM {stock} B
       INNER JOIN {organism} O ON O.organism_id = B.organism_id
       INNER JOIN {cvterm} CVT ON CVT.cvterm_id = B.type_id
-      INNER JOIN {mview_phenotype} P ON P.stock_id=B.stock_id
     WHERE
       (lower(B.uniquename) like lower(:str)
         OR lower(B.name) like lower(:str))
+      AND B.stock_id IN (SELECT stock_id from {mview_phenotype} WHERE trait_id=:trait)
     ORDER by B.name
-    LIMIT 25 OFFSET 0
+    LIMIT 10 OFFSET 0
   ";
-  $records = chado_query($sql, [':str' => $string . '%']);
+  $records = chado_query($sql, [':trait' => $trait_id, ':str' => $string . '%']);
   while ($r = $records->fetchObject()) {
     $key = "$r->name [id: $r->id]";
     $items[$key] = "$r->name ($r->uniquename, $r->type, $r->genus $r->species)";
   }
+
   drupal_json_output($items);
+
 }
 
 /**

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -61,20 +61,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de"
+                "reference": "27a216cbe72327b2d6369fab721a5843be71e57d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/f72816b43e74063c8b10357394b6bba8cb1c10de",
-                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/27a216cbe72327b2d6369fab721a5843be71e57d",
+                "reference": "27a216cbe72327b2d6369fab721a5843be71e57d",
                 "shasum": ""
             },
             "require": {
@@ -83,13 +83,11 @@
             "require-dev": {
                 "ext-intl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "squizlabs/php_codesniffer": "^1.5"
+                "squizlabs/php_codesniffer": "^2.9.2"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
+                "branch-alias": []
             },
             "autoload": {
                 "psr-4": {
@@ -111,7 +109,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2018-07-12T10:23:15+00:00"
+            "time": "2019-11-14T13:13:06+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1755,16 +1753,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.3.6",
+            "version": "v4.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "136c4bd62ea871d00843d1bc0316de4c4a84bb78"
+                "reference": "831424efae0a1fe6642784bd52aae14ece6538e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/136c4bd62ea871d00843d1bc0316de4c4a84bb78",
-                "reference": "136c4bd62ea871d00843d1bc0316de4c4a84bb78",
+                "url": "https://api.github.com/repos/symfony/console/zipball/831424efae0a1fe6642784bd52aae14ece6538e6",
+                "reference": "831424efae0a1fe6642784bd52aae14ece6538e6",
                 "shasum": ""
             },
             "require": {
@@ -1826,7 +1824,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-30T12:58:49+00:00"
+            "time": "2019-11-13T07:29:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2005,16 +2003,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.7",
+            "version": "v1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0"
+                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
-                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
+                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
                 "shasum": ""
             },
             "require": {
@@ -2059,7 +2057,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-09-17T11:12:18+00:00"
+            "time": "2019-10-14T12:27:06+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/includes/TripalFields/ncit__data/ncit__data_formatter.inc
+++ b/includes/TripalFields/ncit__data/ncit__data_formatter.inc
@@ -49,7 +49,8 @@ class ncit__data_formatter extends TripalFieldFormatter {
     drupal_add_css($theme_path . 'style_ncitdata_field.css', 'file');
     drupal_add_js ($theme_path . 'script.js');
 
-    $autocomplete_field = drupal_get_form('analyzedphenotypes_germplasm_search_autocomplete_form', $items);
+    $trait_id = $entity->chado_record_id;
+    $autocomplete_field = drupal_get_form('analyzedphenotypes_germplasm_search_autocomplete_form', $items, $trait_id);
     $field = drupal_render($autocomplete_field);
 
     // Refer to this ID for CSS styling.

--- a/includes/TripalFields/ncit__data/ncit__data_formatterforms.inc
+++ b/includes/TripalFields/ncit__data/ncit__data_formatterforms.inc
@@ -21,7 +21,7 @@ function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_stat
   $form['ap_germplasm_search_autocomplete_textfield'] = array(
     '#type' => 'textfield',
     '#theme_wrappers' => array(),
-    '#autocomplete_path' => 'admin/tripal/storage/chado/auto_name/stock',
+    '#autocomplete_path' => 'admin/tripal/extension/analyzedphenotypes/phenotyped-stock/json',
     '#attributes' => array(
       'placeholder' => 'Germplasm Name or Accession'
     ),
@@ -173,7 +173,7 @@ function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_stat
           $tooltip = '<div class="ap-germplasm-search-tooltip">%s</div>';
           $name = $stockprop->name . ' (' . $stockprop->uniquename . ')';
           if ($chado_bundle) {
-            $name = l($name, url('/bio_data/' . $chado_entity), ['attributes' => ['target' => '_blank']]);
+            $name = l($name, url('bio_data/' . $chado_entity), ['attributes' => ['target' => '_blank']]);
           }
           $element_list = theme('item_list', array(
             'items' => array(

--- a/includes/TripalFields/ncit__data/ncit__data_formatterforms.inc
+++ b/includes/TripalFields/ncit__data/ncit__data_formatterforms.inc
@@ -152,15 +152,7 @@ function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_stat
           } // End group data.
 
           // Fetch entity id that will form part of the url linking to Tripal 3 germplasm page.
-          $chado_bundle = db_query('SELECT t2.name FROM {tripal_term} AS t1 INNER JOIN {tripal_bundle} AS t2 ON t1.id = t2.term_id
-            WHERE t1.accession = (SELECT t3.accession FROM chado.dbxref AS t3 INNER JOIN chado.cvterm AS t4 USING(dbxref_id)
-              WHERE t4.cvterm_id = :stock_type)', array(':stock_type' => $stockprop->type_id))
-            ->fetchField();
-          if ($$chado_bundle) {
-            $entity = sprintf("SELECT entity_id FROM chado_%s WHERE record_id = :stock_id LIMIT 1", $chado_bundle);
-            $chado_entity = chado_query($entity, array(':stock_id' => $stock_id))
-              ->fetchField();
-          }
+          $chado_entity = chado_get_record_entity_by_table('stock', $stock_id);
 
           // Take away duplicate values from the overall summary overview.
           // Order is important see query above.
@@ -172,8 +164,8 @@ function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_stat
 
           $tooltip = '<div class="ap-germplasm-search-tooltip">%s</div>';
           $name = $stockprop->name . ' (' . $stockprop->uniquename . ')';
-          if ($chado_bundle) {
-            $name = l($name, url('bio_data/' . $chado_entity), ['attributes' => ['target' => '_blank']]);
+          if ($chado_entity) {
+            $name = l($name, 'bio_data/' . $chado_entity, ['attributes' => ['target' => '_blank']]);
           }
           $element_list = theme('item_list', array(
             'items' => array(

--- a/includes/TripalFields/ncit__data/ncit__data_formatterforms.inc
+++ b/includes/TripalFields/ncit__data/ncit__data_formatterforms.inc
@@ -16,12 +16,13 @@
  * @see ncit__data_formatter.inc.
  *      ncit__data.inc.
  */
-function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_state, $items) {
+function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_state, $items, $trait_id) {
+
   // FIELD: Autocomplete text field.
   $form['ap_germplasm_search_autocomplete_textfield'] = array(
     '#type' => 'textfield',
     '#theme_wrappers' => array(),
-    '#autocomplete_path' => 'admin/tripal/extension/analyzedphenotypes/phenotyped-stock/json',
+    '#autocomplete_path' => 'admin/tripal/extension/analyzedphenotypes/phenotyped-stock/json/'.$trait_id,
     '#attributes' => array(
       'placeholder' => 'Germplasm Name or Accession'
     ),
@@ -58,7 +59,6 @@ function analyzedphenotypes_germplasm_search_autocomplete_form($form, $form_stat
 
 
   // AJAX RESPONSE:
-
 
   if (isset($form_state['values'])) {
     // AJAX form submitted.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #114 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
This PR ensures that germplasm returned by the autocomplete only include those we have data for the current trait. It also fixes the link to the germplasm page.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

1. Ensure you have data for two experiments. This can be done by running the phenotype seeder 2X as described here: https://analyzedphenotypes.readthedocs.io/en/latest/contribute.html#manual-testing-demonstration
2. Create trait pages for one experiment and publish them.
3. Ensure you can enter the name of germplasm from the same project and have the autocomplete work but not if you enter germplasm from a different experiment. Germplasm names can be determined by checking out the mview_phenotypes table.
4. If on a KnowPulse clone also test that the germplasm link works.